### PR TITLE
FDP-2601: gets rid of extra vivo-index:'' log line that was happening…

### DIFF
--- a/updates.go
+++ b/updates.go
@@ -44,10 +44,7 @@ func (ub UriBatcher) Batch(ctx context.Context, updates chan UpdateMessage) chan
 			select {
 			case u := <-updates:
 				timer.Stop()
-				// check for blank string here? seems wrong
-				if u.Triple.Subject != "" {
-					batch[u.Triple.Subject] = true
-				}
+				batch[u.Triple.Subject] = true
 				if len(batch) == ub.BatchSize {
 					batches <- batch
 					batch = make(map[string]bool, ub.BatchSize)

--- a/vivoindexer.go
+++ b/vivoindexer.go
@@ -68,14 +68,15 @@ func (vi VivoIndexer) Index(batch map[string]bool, logger *log.Logger) (map[stri
 		return batch, err
 	}
 
-	uris := make([]string, len(batch))
+	// NOTE: adding -1 here seemed to get rid of creating
+	// extra "" entry every iteration
+	uris := make([]string, len(batch)-1)
 	for k, _ := range batch {
 		uris = append(uris, k)
 	}
 
 	logger.Printf("vivo-indexer-url:%#v", vi.Url)
 
-	// filter out "" here? how are they making it in?
 	for _, uri := range uris {
 		logger.Printf("->vivo-index:%#v\n", uri)
 	}


### PR DESCRIPTION
… looks like it was because I was allocating array 1 too big