### PR TITLE
Fdp 3244 async batch

### DIFF
--- a/cmd/vivo_indexer/main.go
+++ b/cmd/vivo_indexer/main.go
@@ -177,7 +177,7 @@ func main() {
 		}
 	}()
 
-	// main for-loop of application
+MainLoop:
 	for {
 		select {
 		case b := <-batches:
@@ -186,9 +186,9 @@ func main() {
 		case <-quit:
 			logger.Println("indexer loop closing")
 			cancel()
-			// NOTE: I tried killing the wi-fi locally, and this was
-			// the only way it would shut down (cleanly)
-			os.Exit(1)
+			break MainLoop
 		}
 	}
+
+	os.Exit(1)
 }

--- a/updates.go
+++ b/updates.go
@@ -34,7 +34,8 @@ type UriBatcher struct {
 	BatchTimeout time.Duration
 }
 
-func (ub UriBatcher) Batch(ctx context.Context, updates chan UpdateMessage, logger *log.Logger) chan map[string]bool {
+func (ub UriBatcher) Batch(ctx context.Context, logger *log.Logger,
+	updates chan UpdateMessage, quit chan bool) chan map[string]bool {
 	batches := make(chan map[string]bool)
 
 	go func() {
@@ -55,10 +56,11 @@ func (ub UriBatcher) Batch(ctx context.Context, updates chan UpdateMessage, logg
 					batches <- batch
 					batch = make(map[string]bool, ub.BatchSize)
 				}
-			case <-ctx.Done():
-				err := ctx.Err()
-				logger.Printf("vivoupdater batcher context cancelled:%v\n", err)
+			case <-quit:
+				logger.Println("vivoupdater should quit...")
+				break
 			}
+
 		}
 	}()
 	return batches

--- a/updates.go
+++ b/updates.go
@@ -41,6 +41,7 @@ func (ub UriBatcher) Batch(ctx context.Context, logger *log.Logger,
 	go func() {
 		batch := make(map[string]bool, ub.BatchSize)
 
+	BatchLoop:
 		for {
 			timer := time.NewTimer(ub.BatchTimeout)
 			select {
@@ -57,10 +58,9 @@ func (ub UriBatcher) Batch(ctx context.Context, logger *log.Logger,
 					batch = make(map[string]bool, ub.BatchSize)
 				}
 			case <-quit:
-				logger.Println("vivoupdater should quit...")
-				break
+				logger.Println("vivoupdater batcher received quit=true")
+				break BatchLoop
 			}
-
 		}
 	}()
 	return batches


### PR DESCRIPTION
added a "quit" channel, so when kafka communication is dead it can tell the main thread to stop - seems to avoid segfault when shutting down